### PR TITLE
feat: Optimization objective/constraints, annualized turnover metric, random tuner; universe & weighting utilities; wire optimize_strategy

### DIFF
--- a/src/strategy/backtesting/engine.py
+++ b/src/strategy/backtesting/engine.py
@@ -10,7 +10,7 @@ import pandas as pd
 from dataclasses import dataclass, field
 
 from ..base import BaseStrategy
-from ..models import Signal, Trade, Position, Order, OrderSide, OrderStatus
+from ..models import Signal, Trade, Position, Order, OrderSide, OrderStatus, OrderType
 from ...data.models import Candle, TimeFrame
 from ...data.database import get_db
 
@@ -27,24 +27,25 @@ class BacktestResult:
     end_date: datetime
     initial_capital: float
     final_capital: float
-    
+
     # Trade statistics
     total_trades: int
     winning_trades: int
     losing_trades: int
     win_rate: float
-    
+
     # Returns
     total_return: float
     total_return_pct: float
     annualized_return: float
-    
+
     # Risk metrics
     sharpe_ratio: float
     sortino_ratio: float
     max_drawdown: float
     max_drawdown_duration: int  # days
-    
+    turnover_annualized_pct: float  # Annualized turnover in percent
+
     # Trade analysis
     avg_win: float
     avg_loss: float
@@ -52,12 +53,12 @@ class BacktestResult:
     largest_loss: float
     avg_trade_duration: float  # hours
     profit_factor: float
-    
+
     # Additional metrics
     trades: List[Trade] = field(default_factory=list)
     equity_curve: List[Dict[str, Any]] = field(default_factory=list)
     daily_returns: List[float] = field(default_factory=list)
-    
+
     def to_dict(self) -> Dict[str, Any]:
         """Convert to dictionary."""
         return {
@@ -77,6 +78,7 @@ class BacktestResult:
             'sortino_ratio': self.sortino_ratio,
             'max_drawdown': self.max_drawdown,
             'max_drawdown_duration': self.max_drawdown_duration,
+            'turnover_annualized_pct': self.turnover_annualized_pct,
             'avg_win': self.avg_win,
             'avg_loss': self.avg_loss,
             'largest_win': self.largest_win,
@@ -405,12 +407,32 @@ class BacktestEngine:
         days = (end_date - start_date).days
         years = days / 365.25
         annualized_return = ((final_capital / initial_capital) ** (1 / years) - 1) * 100 if years > 0 else 0
-        
+
+        # Calculate turnover (annualized)
+        # Approximate total traded notional = sum of entry and exit notionals across trades
+        total_traded_notional = 0.0
+        for t in trades:
+            try:
+                entry_val = float(t.entry_price * t.quantity)
+                exit_val = float(t.exit_price * t.quantity)
+            except Exception:
+                entry_val = float(t.entry_price) * float(t.quantity)
+                exit_val = float(t.exit_price) * float(t.quantity)
+            total_traded_notional += abs(entry_val) + abs(exit_val)
+        # Average NAV across the period
+        if equity_curve:
+            avg_nav = float(np.mean([pt['capital'] for pt in equity_curve]))
+        else:
+            avg_nav = (initial_capital + final_capital) / 2.0
+        period_turnover = (total_traded_notional / avg_nav) if avg_nav > 0 else 0.0
+        annualization_factor = (365.25 / days) if days > 0 else 0.0
+        turnover_annualized_pct = period_turnover * annualization_factor * 100.0
+
         # Calculate risk metrics
         sharpe_ratio = self._calculate_sharpe_ratio(daily_returns, self.risk_free_rate)
         sortino_ratio = self._calculate_sortino_ratio(daily_returns, self.risk_free_rate)
         max_drawdown, max_dd_duration = self._calculate_max_drawdown(equity_curve)
-        
+
         return BacktestResult(
             strategy_name=strategy.name,
             start_date=start_date,
@@ -428,6 +450,7 @@ class BacktestEngine:
             sortino_ratio=sortino_ratio,
             max_drawdown=max_drawdown,
             max_drawdown_duration=max_dd_duration,
+            turnover_annualized_pct=turnover_annualized_pct,
             avg_win=avg_win,
             avg_loss=avg_loss,
             largest_win=largest_win,
@@ -664,6 +687,7 @@ class BacktestEngine:
             sortino_ratio=0.0,
             max_drawdown=0.0,
             max_drawdown_duration=0,
+            turnover_annualized_pct=0.0,
             avg_win=0.0,
             avg_loss=0.0,
             largest_win=0.0,

--- a/src/strategy/optimization/__init__.py
+++ b/src/strategy/optimization/__init__.py
@@ -1,0 +1,3 @@
+from .objective import ObjectiveConfig, compute_objective_weighted, check_constraints
+from .tuner import optimize, sample_params
+

--- a/src/strategy/optimization/objective.py
+++ b/src/strategy/optimization/objective.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class ObjectiveConfig:
+    # Objective weights
+    w1: float = 1.0  # annualized return weight
+    w2: float = 1.0  # Sharpe weight
+    w3: float = 1.0  # MaxDD penalty weight
+
+    # Constraints
+    max_dd_limit_pct: float = 15.0   # Maximum Drawdown limit in percent
+    turnover_limit_annualized_pct: float = 200.0  # Annualized turnover limit in percent
+
+
+def compute_objective(result) -> float:
+    """Compute objective value based on BacktestResult.
+
+    objective = annualized_return * w1 + sharpe * w2 - max_dd * w3
+    """
+    return (
+        float(getattr(result, 'annualized_return', 0.0)) * 1.0
+        + float(getattr(result, 'sharpe_ratio', 0.0)) * 1.0
+        - float(getattr(result, 'max_drawdown', 0.0)) * 1.0
+    )
+
+
+def compute_objective_weighted(result, cfg: ObjectiveConfig) -> float:
+    return (
+        float(getattr(result, 'annualized_return', 0.0)) * cfg.w1
+        + float(getattr(result, 'sharpe_ratio', 0.0)) * cfg.w2
+        - float(getattr(result, 'max_drawdown', 0.0)) * cfg.w3
+    )
+
+
+def check_constraints(result, cfg: ObjectiveConfig) -> Dict[str, bool]:
+    """Check constraints based on BacktestResult.
+
+    Returns a dict of constraint_name -> satisfied(bool).
+    """
+    satisfied = {}
+
+    max_dd = float(getattr(result, 'max_drawdown', 0.0))
+    turnover_annualized_pct = float(getattr(result, 'turnover_annualized_pct', 0.0))
+
+    satisfied['max_drawdown'] = max_dd <= cfg.max_dd_limit_pct
+    satisfied['turnover'] = turnover_annualized_pct <= cfg.turnover_limit_annualized_pct
+
+    return satisfied
+

--- a/src/strategy/optimization/tuner.py
+++ b/src/strategy/optimization/tuner.py
@@ -1,0 +1,102 @@
+import asyncio
+import random
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Dict, List, Tuple, Optional
+
+from .objective import ObjectiveConfig, compute_objective_weighted, check_constraints
+from ..backtesting.engine import BacktestEngine
+
+
+@dataclass
+class TrialResult:
+    params: Dict[str, Any]
+    objective: float
+    constraints_ok: bool
+    metrics: Dict[str, Any]
+
+
+def _sample_param_value(spec: Dict[str, Any], rng: random.Random):
+    if 'choices' in spec:
+        return rng.choice(spec['choices'])
+    low = spec.get('min')
+    high = spec.get('max')
+    step = spec.get('step')
+    if low is None or high is None:
+        raise ValueError("Parameter spec must include min and max or choices")
+    if step:
+        n_steps = int((high - low) / step)
+        k = rng.randint(0, n_steps)
+        return low + k * step
+    # float uniform
+    return rng.uniform(low, high)
+
+
+def sample_params(parameter_ranges: Dict[str, Dict[str, Any]], n_samples: int, seed: int = 42) -> List[Dict[str, Any]]:
+    rng = random.Random(seed)
+    samples = []
+    keys = list(parameter_ranges.keys())
+    for _ in range(n_samples):
+        params = {}
+        for k in keys:
+            params[k] = _sample_param_value(parameter_ranges[k], rng)
+        samples.append(params)
+    return samples
+
+
+async def evaluate_once(
+    strategy_cls,
+    params: Dict[str, Any],
+    symbols: List[str],
+    start_date: datetime,
+    end_date: datetime,
+    engine: BacktestEngine,
+    objective_cfg: ObjectiveConfig
+) -> TrialResult:
+    strategy = strategy_cls(symbols=symbols, **params)
+    result = await engine.run_backtest(strategy=strategy, start_date=start_date, end_date=end_date, symbols=symbols)
+    objective_value = compute_objective_weighted(result, objective_cfg)
+    constraints = check_constraints(result, objective_cfg)
+    constraints_ok = all(constraints.values())
+    metrics = result.to_dict()
+    metrics['constraints'] = constraints
+    metrics['objective'] = objective_value
+    return TrialResult(params=params, objective=objective_value, constraints_ok=constraints_ok, metrics=metrics)
+
+
+async def optimize(
+    strategy_cls,
+    symbols: List[str],
+    start_date: datetime,
+    end_date: datetime,
+    parameter_ranges: Dict[str, Dict[str, Any]],
+    objective_cfg: Optional[ObjectiveConfig] = None,
+    n_initial_samples: int = 20,
+    seed: int = 42,
+) -> Tuple[Dict[str, Any], TrialResult, List[TrialResult]]:
+    """Simple random-search optimizer with constraints filtering.
+
+    Returns best_params, best_trial, all_trials
+    """
+    if objective_cfg is None:
+        objective_cfg = ObjectiveConfig()
+
+    samples = sample_params(parameter_ranges, n_initial_samples, seed)
+    engine = BacktestEngine()
+
+    trials: List[TrialResult] = []
+    best_trial: Optional[TrialResult] = None
+
+    for params in samples:
+        trial = await evaluate_once(strategy_cls, params, symbols, start_date, end_date, engine, objective_cfg)
+        trials.append(trial)
+        if trial.constraints_ok:
+            if best_trial is None or trial.objective > best_trial.objective:
+                best_trial = trial
+
+    if best_trial is None:
+        # If no trial met constraints, pick the least violating by objective anyway
+        best_trial = max(trials, key=lambda t: t.objective)
+
+    return best_trial.params, best_trial, trials
+

--- a/src/strategy/portfolio/weighting.py
+++ b/src/strategy/portfolio/weighting.py
@@ -1,0 +1,52 @@
+from typing import List, Dict
+import numpy as np
+
+
+def _simplex_projection(v: np.ndarray) -> np.ndarray:
+    # Euclidean projection onto simplex {w >=0, sum w = 1}
+    n = v.shape[0]
+    u = np.sort(v)[::-1]
+    cssv = np.cumsum(u)
+    rho = np.nonzero(u * np.arange(1, n+1) > (cssv - 1))[0][-1]
+    theta = (cssv[rho] - 1) / (rho + 1)
+    w = np.maximum(v - theta, 0)
+    return w
+
+
+def volatility_targeting(sigmas: np.ndarray, target_vol: float = None) -> np.ndarray:
+    inv_vol = 1.0 / np.maximum(sigmas, 1e-8)
+    w = inv_vol / inv_vol.sum()
+    # optional scaling to target vol at portfolio level can be applied downstream
+    return w
+
+
+def risk_parity(cov: np.ndarray, tol: float = 1e-6, max_iter: int = 1000) -> np.ndarray:
+    n = cov.shape[0]
+    w = np.ones(n) / n
+    for _ in range(max_iter):
+        port_var = w @ cov @ w
+        mrc = cov @ w  # marginal risk contributions
+        rc = w * mrc    # risk contributions
+        target = port_var / n
+        grad = mrc * 2 * w - target  # heuristic gradient
+        w_new = w - 0.01 * grad
+        w_new = _simplex_projection(w_new)
+        if np.linalg.norm(w_new - w, 1) < tol:
+            return w_new
+        w = w_new
+    return w
+
+
+def mean_variance_with_dd_penalty(mu: np.ndarray, cov: np.ndarray, dd_penalty: float = 0.0, lr: float = 0.01, iters: int = 200) -> np.ndarray:
+    # maximize mu^T w - lambda w^T C w - gamma * DD_penalty(w)
+    # here approximate DD penalty by k * sqrt(w^T C w) for simplicity
+    n = mu.shape[0]
+    lam = 1.0
+    gamma = dd_penalty
+    w = np.ones(n) / n
+    for _ in range(iters):
+        grad = mu - 2 * lam * (cov @ w) - 0.5 * gamma * (cov @ w) / max(np.sqrt(w @ cov @ w), 1e-8)
+        w = w + lr * grad
+        w = _simplex_projection(w)
+    return w
+

--- a/src/strategy/universe.py
+++ b/src/strategy/universe.py
@@ -1,0 +1,57 @@
+from typing import List, Dict, Any
+import json
+import numpy as np
+
+
+def load_all_symbols(limit: int = None) -> List[str]:
+    with open('config/all_us_stocks_symbols.json') as f:
+        data = json.load(f)
+    symbols = data.get('symbols', [])
+    if limit:
+        symbols = symbols[:limit]
+    return symbols
+
+
+def select_universe_by_liquidity(
+    symbols: List[str],
+    get_volume_fn,
+    min_avg_dollar_volume: float,
+    top_n: int = 10
+) -> List[str]:
+    """Select universe by average dollar volume.
+
+    get_volume_fn(symbols) should return dict symbol -> avg_dollar_volume.
+    """
+    vols: Dict[str, float] = get_volume_fn(symbols)
+    ranked = sorted([s for s in symbols if s in vols], key=lambda s: vols[s], reverse=True)
+    return ranked[:top_n]
+
+
+def diversify_by_correlation(
+    returns_matrix: np.ndarray,
+    symbols: List[str],
+    target_n: int
+) -> List[str]:
+    """Greedy selection minimizing average correlation."""
+    corr = np.corrcoef(returns_matrix, rowvar=False)
+    selected: List[int] = []
+    remaining = set(range(len(symbols)))
+    # start with the least average correlation
+    avg_corr = np.mean(np.abs(corr), axis=1)
+    first = int(np.argmin(avg_corr))
+    selected.append(first)
+    remaining.remove(first)
+
+    while len(selected) < target_n and remaining:
+        best_idx = None
+        best_score = float('inf')
+        for i in remaining:
+            score = np.mean(np.abs(corr[i, selected]))
+            if score < best_score:
+                best_score = score
+                best_idx = i
+        selected.append(best_idx)
+        remaining.remove(best_idx)
+
+    return [symbols[i] for i in selected]
+

--- a/src/tasks/backtesting.py
+++ b/src/tasks/backtesting.py
@@ -130,64 +130,67 @@ def optimize_strategy(
     logger.info(f"[Task {self.request.id}] Optimizing strategy {strategy_id}")
     
     try:
-        # Phase 3에서 실제 구현 예정
-        # 현재는 시뮬레이션
-        
-        # 1. 파라미터 조합 생성
-        # param_combinations = generate_parameter_grid(parameter_ranges)
-        total_combinations = 50  # 시뮬레이션
-        
-        # 2. 베이지안 최적화 또는 그리드 서치
-        # optimizer = BayesianOptimizer(objective_function)
-        
-        # 3. 병렬 백테스트 실행
-        tested = 0
-        best_sharpe = 0.0
-        best_params = {}
-        
-        # 진행 상황 업데이트
-        for i in range(min(20, total_combinations)):  # 시뮬레이션: 20개만 테스트
-            tested += 1
-            self.update_state(
-                state='PROGRESS',
-                meta={
-                    'current': tested,
-                    'total': total_combinations,
-                    'best_sharpe': best_sharpe,
-                    'status': f'Testing combination {tested}/{total_combinations}'
-                }
+        from src.api.routers.strategies import STRATEGY_REGISTRY, strategies_store
+        from src.strategy.optimization.objective import ObjectiveConfig
+        from src.strategy.optimization.tuner import optimize as optimize_random
+        from datetime import datetime as dt
+
+        if strategy_id not in strategies_store:
+            raise ValueError(f"Strategy not found: {strategy_id}")
+        strategy_data = strategies_store[strategy_id]
+        strategy_type = strategy_data["type"]
+        if strategy_type not in STRATEGY_REGISTRY:
+            raise ValueError(f"Unknown strategy type: {strategy_type}")
+        strategy_cls = STRATEGY_REGISTRY[strategy_type]
+
+        # Parse dates
+        start_dt = dt.fromisoformat(start_date)
+        end_dt = dt.fromisoformat(end_date)
+
+        # Objective/constraints config (defaults based on user input)
+        cfg = ObjectiveConfig(
+            w1=1.0, w2=1.0, w3=1.0,
+            max_dd_limit_pct=15.0,
+            turnover_limit_annualized_pct=200.0
+        )
+
+        # Run simple random search optimizer
+        best_params, best_trial, trials = asyncio.get_event_loop().run_until_complete(
+            optimize_random(
+                strategy_cls=strategy_cls,
+                symbols=symbols,
+                start_date=start_dt,
+                end_date=end_dt,
+                parameter_ranges=parameter_ranges,
+                objective_cfg=cfg,
+                n_initial_samples=20,
+                seed=42,
             )
-            
-            # 시뮬레이션: 무작위 성능
-            sharpe = np.random.uniform(0.5, 2.5)
-            if sharpe > best_sharpe:
-                best_sharpe = sharpe
-                best_params = {
-                    "fast_period": np.random.randint(5, 20),
-                    "slow_period": np.random.randint(20, 50)
-                }
-        
+        )
+
+        # Progress/meta
+        self.update_state(
+            state='PROGRESS',
+            meta={
+                'current': len(trials),
+                'total': len(trials),
+                'status': 'Optimization complete',
+                'best_objective': best_trial.objective,
+            }
+        )
+
         return {
             "status": "success",
             "task_id": self.request.id,
             "strategy_id": strategy_id,
-            "optimization_method": "bayesian",
-            "iterations": tested,
-            "total_combinations": total_combinations,
+            "optimization_method": "random_search",
+            "iterations": len(trials),
             "best_parameters": best_params,
-            "best_performance": {
-                "sharpe_ratio": best_sharpe,
-                "total_return": best_sharpe * 8.5,  # 시뮬레이션
-                "max_drawdown": -5.5 / best_sharpe,  # 시뮬레이션
-                "win_rate": 0.45 + (best_sharpe * 0.1)  # 시뮬레이션
-            },
-            "parameter_importance": {
-                "fast_period": 0.7,
-                "slow_period": 0.3
-            },
-            "message": f"Found optimal parameters after {tested} iterations"
+            "best_performance": best_trial.metrics,
+            "all_trials": [t.metrics for t in trials],
+            "message": f"Found optimal parameters after {len(trials)} evaluations"
         }
-    
+
     except Exception as e:
         logger.error(f"[Task {self.request.id}] Error in optimization: {e}")
         return {


### PR DESCRIPTION
Summary
- Add Objective/Constraints module (ObjectiveConfig, compute_objective_weighted, check_constraints) with defaults w1=w2=w3=1, MaxDD<=15%, Turnover<=200%
- Backtesting engine: add annualized turnover (turnover_annualized_pct) to BacktestResult; compute from trade notional and average NAV; include in to_dict and empty result
- Add simple random-search tuner with reproducible seed; evaluates BacktestEngine and honors constraints
- Wire Celery optimize_strategy to call real optimizer (via STRATEGY_REGISTRY), returning best_params and best trial metrics
- Add universe utilities (load_all_symbols, liquidity selection, correlation diversification)
- Add portfolio weighting utilities (volatility targeting, risk parity, mean-variance with DD penalty)

Notes
- Turnover is currently an approximation based on trade notional; can be refined to weight-change based calculation later
- Tests: pytest in repo currently requires pytest>=7 but environment has 6.2.5; compilation passes (python -m compileall). I can update pytest on request

Next steps (separate PRs suggested)
- Introduce Optuna/Hyperopt-based TPE/Hyperband with early stopping
- Add accurate liquidity data path from DB and integrate universe selection into backtest/optimizer
- Integrate weighting utilities into position sizing; add long/short exposure constraints
- Add/adjust unit tests for new metrics and optimizer


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author